### PR TITLE
fix: Update postUrl to include authorDid in URL

### DIFF
--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -384,7 +384,7 @@ export function PostPage() {
         author={author || undefined}
         source={entry.source}
         blobs={entry.blobs}
-        postUrl={`${window.location.origin}/${handle}/${rkey},https://whtwnd.com/${handle}/${rkey}`}
+        postUrl={`${window.location.origin}/${handle}/${rkey},https://whtwnd.com/${handle}/${rkey},${window.location.origin}/${entry.authorDid}/${rkey},https://whtwnd.com/${entry.authorDid}/${rkey}`}
         tags={entry.tags}
         publicationVoiceTheme={publication?.voiceTheme}
       />


### PR DESCRIPTION
Currently, the bluesky interaction component only retrieves post URLs that are prefixed with the user's handle. This causes problems in some cases, for example, my AI agent LingClaw publishes blog post urls using her DID instead of her handle. This PR fixes this issue.